### PR TITLE
Add errata note for mistake in <stretchy-vector> description

### DIFF
--- a/source/Collection_Classes.html
+++ b/source/Collection_Classes.html
@@ -1314,8 +1314,14 @@
 	    specified subclasses, every implementation must provide one or more concrete subclass to
 	    instantiate. These concrete subclasses have no specified names, and their names are not
 	    exported by the Dylan module.</p>
-	  <p>The element type of <code>&lt;simple-vector&gt;</code> is <code>indefinite &lArr;
-	      &lt;object&gt;</code>.</p></dd>
+	  <p>The element type of <code>&lt;stretchy-vector&gt;</code> is <code>indefinite &lArr;
+	      &lt;object&gt;</code>.</p>
+	  <p class="errata-note" id="errata-p224-1">
+	    <a class="note-tag" href="Errata#p224-1"><strong>Errata:</strong></a>
+	    In the published book, the above sentence said <code>&lt;simple-vector&gt;</code>
+	    instead of <code>&lt;stretchy-vector&gt;</code>.
+	  </p>
+	</dd>
 	<dt><span>Operations:</span></dt>
 	<dd><p>The class <code>&lt;stretchy-vector&gt;</code> provides the following operations:</p>
 	  <table class="numbered">

--- a/source/Errata.html
+++ b/source/Errata.html
@@ -165,7 +165,11 @@
       <li id="p207-1"><a href="Collection_Classes#errata-p207-1">p. 207</a>, the collection classes
         diagram has an arrow leading to various vector &amp; string classes
         from <tt>&lt;empty-list&gt;</tt>. It should actually lead from <tt>&lt;vector&gt;</tt>.</li>
-      
+
+      <li id="p224-1"><a href="Collection_Classes#errata-p224-1">p. 224</a>, the description of
+        <tt>&lt;stretchy-vector&gt;</tt> says "the element type of <tt>&lt;simple-vector&gt;</tt>"
+        where it should say "the element type of <tt>&lt;stretchy-vector&gt;</tt>."</li>
+
       <li id="p263-1"><a href="Constructing_and_Initializing_Instances#errata-p263-1">p. 263</a>,
         the default value for the <i>by</i> argument to <tt>make</tt> of <tt>&lt;range&gt;</tt>
         should be <tt>1</tt>, not <tt>0</tt>.</li>


### PR DESCRIPTION
The description says "The element type of `<simple-vector>` is `indefinite <= <object>`" but it should say "The element type of `<stretchy-vector>` is `indefinite <= <object>`"