### PR TITLE
Fix list of exported function names

### DIFF
--- a/source/Exported_Names.html
+++ b/source/Exported_Names.html
@@ -204,20 +204,20 @@
       <h2 class="subsection-title">Exported Functions</h2>
       <p>One hundred sixty-nine names exported from the Dylan module are bound to functions.</p>
       <pre class="NF.NameEntryFirst">
-\*
-\+
-\-
-\/
-\&lt;
-\&lt;=
-\=
-\==
-\&gt;
-\&gt;=
-\^
-\~
-\~=
-\~==
+*
++
+-
+/
+&lt;
+&lt;=
+=
+==
+&gt;
+&gt;=
+^
+~
+~=
+~==
 abort
 abs
 add
@@ -281,8 +281,7 @@ function-arguments
 function-return-values
 function-specializers
 gcd
-generic-function-mandatory-
-keywords
+generic-function-mandatory-keywords
 generic-function-methods
 head
 head-setter


### PR DESCRIPTION
* many had an unnecessary preceding backslash
* generic-function-mandatory-keywords was split across two lines

(Untested. Creating a pull request so I don't forget about this branch. I need to figure out how to setup a web server that will automatically assume `.html` file extensions. Why is there no README in this repo grumble grumble.)